### PR TITLE
Add GitHub Skills activity to resolve missing activity issue

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Resolves Issue
Fixes #6 - Missing Activity: GitHub Skills

## 📋 Summary
This PR adds the **GitHub Skills** activity that was announced by the principal but was missing from the school activities signup page. This is a time-sensitive fix as registrations close by the end of this week.

## ✨ Changes Made
- Added `"GitHub Skills"` to the activities dictionary in `app.py`
- **Description**: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications
- **Schedule**: Mondays and Wednesdays, 3:30 PM - 4:30 PM  
- **Max Participants**: 25 students (increased capacity due to expected high demand)
- **Participants**: Empty list ready for student registrations

## 🧪 Testing
- [x] Activity structure follows existing pattern
- [x] Includes all required fields (description, schedule, max_participants, participants)
- [x] Description mentions GitHub Certifications program as referenced in the issue

## 📝 Context
The principal announced this new partnership with GitHub in the school assembly to teach students practical coding and collaboration skills. The activity is part of the GitHub Certifications program which will help students with college applications. Students have been unable to register until now.

## ⏱️ Priority
**HIGH** - Registration deadline is end of this week per the original announcement.